### PR TITLE
Historia 6: implementar endpoints enable/disable 

### DIFF
--- a/FeatureFlag7 Tests.postman_collection.json
+++ b/FeatureFlag7 Tests.postman_collection.json
@@ -1,10 +1,10 @@
 {
 	"info": {
-		"_postman_id": "5edc891e-96c0-4ad2-a365-ecf998cf652a",
+		"_postman_id": "385d084d-b62e-4713-85ce-34a45423324e",
 		"name": "FeatureFlag7 - API (Tests)",
 		"description": "Pruebas completas (Auth, Features, Gestión, Check, Filtros y Errores) para la API de FeatureFlag7.\n\nIncluye casos exitosos y de error para una cobertura completa.",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-		"_exporter_id": "45943072"
+		"_exporter_id": "28382583"
 	},
 	"item": [
 		{
@@ -220,6 +220,16 @@
 				{
 					"name": "Create Feature - POST /api/features (OK)",
 					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJyb2RyaSIsInJvbGUiOiJVU0VSIiwiaWF0IjoxNzU4MDg2Mjg2LCJleHAiOjE3NTgwODk4ODZ9.BsvuyrrAaJKZPBQNROU1-GLPRxnIZKoNGryrW3WTfOYE25sVPO5zGomOoZirVHeSfwYH1X0KNj9OLoEfevX-pA",
+									"type": "string"
+								}
+							]
+						},
 						"method": "POST",
 						"header": [
 							{
@@ -441,6 +451,16 @@
 				{
 					"name": "List All Features - GET /api/features",
 					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJyb2RyaSIsInJvbGUiOiJVU0VSIiwiaWF0IjoxNzU4MDkyOTA5LCJleHAiOjE3NTgwOTY1MDl9.GMBye4s9zgnQaKzHCovlrCkhh0kdJ0-gl7HzmEVd7XQ5RsscRmQfkCRh5efOaZZZxlo-sgZnCHsNh_0uf2_hqA",
+									"type": "string"
+								}
+							]
+						},
 						"method": "GET",
 						"header": [
 							{
@@ -497,7 +517,17 @@
 				{
 					"name": "Get Feature by ID - GET /api/features/{id} (OK)",
 					"request": {
-						"method": "POST",
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJyb2RyaSIsInJvbGUiOiJVU0VSIiwiaWF0IjoxNzU4MDkyOTA5LCJleHAiOjE3NTgwOTY1MDl9.GMBye4s9zgnQaKzHCovlrCkhh0kdJ0-gl7HzmEVd7XQ5RsscRmQfkCRh5efOaZZZxlo-sgZnCHsNh_0uf2_hqA",
+									"type": "string"
+								}
+							]
+						},
+						"method": "GET",
 						"header": [
 							{
 								"key": "Authorization",
@@ -505,7 +535,7 @@
 							}
 						],
 						"url": {
-							"raw": "http://localhost:8080/api/features/{{featureId}}}",
+							"raw": "http://localhost:8080/api/features/91972f1c-70a1-462c-8aa7-3fb524f07149",
 							"protocol": "http",
 							"host": [
 								"localhost"
@@ -514,7 +544,7 @@
 							"path": [
 								"api",
 								"features",
-								"{{featureId}}}"
+								"91972f1c-70a1-462c-8aa7-3fb524f07149"
 							]
 						}
 					},
@@ -591,6 +621,16 @@
 				{
 					"name": "Enable Feature - POST /api/features/{id}/enable",
 					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJyb2RyaSIsInJvbGUiOiJVU0VSIiwiaWF0IjoxNzU4MDkyOTA5LCJleHAiOjE3NTgwOTY1MDl9.GMBye4s9zgnQaKzHCovlrCkhh0kdJ0-gl7HzmEVd7XQ5RsscRmQfkCRh5efOaZZZxlo-sgZnCHsNh_0uf2_hqA",
+									"type": "string"
+								}
+							]
+						},
 						"method": "POST",
 						"header": [
 							{
@@ -604,10 +644,10 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{ \"environment\": \"PROD\", \"clientId\": \"acme123\" }"
+							"raw": "{ \"environment\": \"STAGING\", \"clientId\": \"acme123\" }"
 						},
 						"url": {
-							"raw": "http://localhost:8080/api/features/{{featureId}}}/enable",
+							"raw": "http://localhost:8080/api/features/91972f1c-70a1-462c-8aa7-3fb524f07149/enable",
 							"protocol": "http",
 							"host": [
 								"localhost"
@@ -616,7 +656,7 @@
 							"path": [
 								"api",
 								"features",
-								"{{featureId}}}",
+								"91972f1c-70a1-462c-8aa7-3fb524f07149",
 								"enable"
 							]
 						}
@@ -707,6 +747,16 @@
 				{
 					"name": "Disable Feature - POST /api/features/{id}/disable",
 					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJyb2RyaSIsInJvbGUiOiJVU0VSIiwiaWF0IjoxNzU4MDkyOTA5LCJleHAiOjE3NTgwOTY1MDl9.GMBye4s9zgnQaKzHCovlrCkhh0kdJ0-gl7HzmEVd7XQ5RsscRmQfkCRh5efOaZZZxlo-sgZnCHsNh_0uf2_hqA",
+									"type": "string"
+								}
+							]
+						},
 						"method": "POST",
 						"header": [
 							{
@@ -720,10 +770,10 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{ \"environment\": \"PROD\", \"clientId\": \"acme123\" }"
+							"raw": "{ \"environment\": \"STAGING\", \"clientId\": \"acme123\" }"
 						},
 						"url": {
-							"raw": "http://localhost:8080/api/features/{{featureId}}}/disable",
+							"raw": "http://localhost:8080/api/features/91972f1c-70a1-462c-8aa7-3fb524f07149/disable",
 							"protocol": "http",
 							"host": [
 								"localhost"
@@ -732,7 +782,7 @@
 							"path": [
 								"api",
 								"features",
-								"{{featureId}}}",
+								"91972f1c-70a1-462c-8aa7-3fb524f07149",
 								"disable"
 							]
 						}
@@ -782,7 +832,20 @@
 				},
 				{
 					"name": "Check Feature - GET /api/features/check",
+					"protocolProfileBehavior": {
+						"disableBodyPruning": true
+					},
 					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJyb2RyaSIsInJvbGUiOiJVU0VSIiwiaWF0IjoxNzU4MDkyOTA5LCJleHAiOjE3NTgwOTY1MDl9.GMBye4s9zgnQaKzHCovlrCkhh0kdJ0-gl7HzmEVd7XQ5RsscRmQfkCRh5efOaZZZxlo-sgZnCHsNh_0uf2_hqA",
+									"type": "string"
+								}
+							]
+						},
 						"method": "GET",
 						"header": [
 							{
@@ -790,8 +853,17 @@
 								"value": "Bearer {{token}}"
 							}
 						],
+						"body": {
+							"mode": "raw",
+							"raw": "",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
 						"url": {
-							"raw": "http://localhost:8080/api/features/check?feature=dark_mode&clientId=acme123&env=DEV",
+							"raw": "http://localhost:8080/api/features/check?feature=dark_mode&clientId=acme123&env=STAGING",
 							"protocol": "http",
 							"host": [
 								"localhost"
@@ -813,7 +885,7 @@
 								},
 								{
 									"key": "env",
-									"value": "DEV"
+									"value": "STAGING"
 								}
 							]
 						}
@@ -919,6 +991,16 @@
 				{
 					"name": "Filter by enabled - GET /api/features?enabled=true",
 					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJyb2RyaSIsInJvbGUiOiJVU0VSIiwiaWF0IjoxNzU4MDkyOTA5LCJleHAiOjE3NTgwOTY1MDl9.GMBye4s9zgnQaKzHCovlrCkhh0kdJ0-gl7HzmEVd7XQ5RsscRmQfkCRh5efOaZZZxlo-sgZnCHsNh_0uf2_hqA",
+									"type": "string"
+								}
+							]
+						},
 						"method": "GET",
 						"header": [
 							{
@@ -987,6 +1069,16 @@
 				{
 					"name": "Filter by name - GET /api/features?name=dark_mode",
 					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJyb2RyaSIsInJvbGUiOiJVU0VSIiwiaWF0IjoxNzU4MDkyOTA5LCJleHAiOjE3NTgwOTY1MDl9.GMBye4s9zgnQaKzHCovlrCkhh0kdJ0-gl7HzmEVd7XQ5RsscRmQfkCRh5efOaZZZxlo-sgZnCHsNh_0uf2_hqA",
+									"type": "string"
+								}
+							]
+						},
 						"method": "GET",
 						"header": [
 							{
@@ -1098,9 +1190,6 @@
 						{
 							"name": "401 Unauthorized - no token",
 							"originalRequest": {
-								"auth": {
-									"type": "noauth"
-								},
 								"method": "GET",
 								"header": [
 									{
@@ -1112,10 +1201,6 @@
 										"value": "application/json"
 									}
 								],
-								"body": {
-									"mode": "raw",
-									"raw": "{\n  \"name\": \"dark_mode\",\n  \"description\": \"Duplicado\",\n  \"enabledByDefault\": false\n}"
-								},
 								"url": {
 									"raw": "http://localhost:8080/api/features",
 									"protocol": "http",

--- a/src/main/java/com/bytes7/feature_flag7/controller/FeatureController.java
+++ b/src/main/java/com/bytes7/feature_flag7/controller/FeatureController.java
@@ -4,6 +4,7 @@ import com.bytes7.feature_flag7.dto.*;
 import com.bytes7.feature_flag7.model.Feature;
 import com.bytes7.feature_flag7.model.FeatureConfig;
 import com.bytes7.feature_flag7.repository.FeatureRepository;
+import com.bytes7.feature_flag7.service.FeatureConfigService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -25,9 +26,11 @@ import java.util.UUID;
 public class FeatureController {
 
     private final FeatureRepository featureRepository;
+    private final FeatureConfigService featureConfigService;
 
-    public FeatureController(FeatureRepository featureRepository) {
+    public FeatureController(FeatureRepository featureRepository, FeatureConfigService featureConfigService) {
         this.featureRepository = featureRepository;
+        this.featureConfigService = featureConfigService;
     }
 
     // ==============================
@@ -103,6 +106,40 @@ public FeatureResponse createFeature(@Valid @RequestBody FeatureRequest request)
         }
         Feature feature = featureRepository.getReferenceById(uuid);
         return ResponseEntity.ok(FeatureResponse.fromEntity(feature));
+    }
+
+    // ==============================
+    // POST /api/features/{id}/enable
+    // POST /api/features/{id}/disable
+    // ==============================
+    @PostMapping("/{id}/enable")
+    @Operation(summary = "Habilitar feature", description = "Habilita una feature para un cliente o entorno específico")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Feature habilitada exitosamente"),
+            @ApiResponse(responseCode = "400", description = "Solicitud inválida", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "Feature no encontrada", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public ResponseEntity<FeatureConfigResponse> enableFeature(
+            @PathVariable String id,
+            @Valid @RequestBody FeatureToggleRequest request) {
+
+        UUID uuid = UUID.fromString(id);
+        return ResponseEntity.ok(featureConfigService.enableFeature(uuid, request));
+    }
+
+    @PostMapping("/{id}/disable")
+    @Operation(summary = "Deshabilitar feature", description = "Deshabilita una feature para un cliente o entorno específico")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Feature deshabilitada exitosamente"),
+            @ApiResponse(responseCode = "400", description = "Solicitud inválida", content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+            @ApiResponse(responseCode = "404", description = "Feature no encontrada", content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    public ResponseEntity<FeatureConfigResponse> disableFeature(
+            @PathVariable String id,
+            @Valid @RequestBody FeatureToggleRequest request) {
+
+        UUID uuid = UUID.fromString(id);
+        return ResponseEntity.ok(featureConfigService.disableFeature(uuid, request));
     }
 
 }

--- a/src/main/java/com/bytes7/feature_flag7/dto/FeatureToggleRequest.java
+++ b/src/main/java/com/bytes7/feature_flag7/dto/FeatureToggleRequest.java
@@ -1,0 +1,13 @@
+package com.bytes7.feature_flag7.dto;
+
+import com.bytes7.feature_flag7.backend.enums.Environment;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record FeatureToggleRequest(
+        @NotNull(message = "El entorno es obligatorio")
+        Environment environment,
+        @Size(max = 50, message = "El clientId no debe superar los 50 caracteres")
+        String clientId
+) {}

--- a/src/main/java/com/bytes7/feature_flag7/service/FeatureConfigService.java
+++ b/src/main/java/com/bytes7/feature_flag7/service/FeatureConfigService.java
@@ -1,0 +1,76 @@
+package com.bytes7.feature_flag7.service;
+
+import com.bytes7.feature_flag7.backend.enums.Environment;
+import com.bytes7.feature_flag7.dto.FeatureConfigRequest;
+import com.bytes7.feature_flag7.dto.FeatureConfigResponse;
+import com.bytes7.feature_flag7.dto.FeatureToggleRequest;
+import com.bytes7.feature_flag7.model.Feature;
+import com.bytes7.feature_flag7.model.FeatureConfig;
+import com.bytes7.feature_flag7.repository.FeatureConfigRepository;
+import com.bytes7.feature_flag7.repository.FeatureRepository;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.UUID;
+
+@Service
+public class FeatureConfigService {
+
+    private final FeatureRepository featureRepository;
+    private final FeatureConfigRepository featureConfigRepository;
+
+    public FeatureConfigService(FeatureRepository featureRepository,
+                                FeatureConfigRepository featureConfigRepository) {
+        this.featureRepository = featureRepository;
+        this.featureConfigRepository = featureConfigRepository;
+    }
+
+    public FeatureConfigResponse enableFeature(UUID featureId, FeatureToggleRequest request) {
+        Feature feature = featureRepository.findById(featureId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Feature no encontrada"));
+
+        if (request.clientId() == null && request.environment() == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Debe especificar clientId o environment");
+        }
+
+        FeatureConfig config = featureConfigRepository
+                .findByFeatureIdAndEnvironmentAndClientId(featureId, request.environment(), request.clientId())
+                .orElseGet(() -> {
+                    FeatureConfig newConfig = new FeatureConfig();
+                    newConfig.setFeature(feature);
+                    newConfig.setClientId(request.clientId());
+                    newConfig.setEnvironment(request.environment());
+                    return newConfig;
+                });
+
+        config.setEnabled(true);
+
+        FeatureConfig saved = featureConfigRepository.save(config);
+        return FeatureConfigResponse.fromEntity(saved);
+    }
+
+    public FeatureConfigResponse disableFeature(UUID featureId, FeatureToggleRequest request) {
+        Feature feature = featureRepository.findById(featureId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Feature no encontrada"));
+
+        if (request.clientId() == null && request.environment() == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Debe especificar clientId o environment");
+        }
+
+        FeatureConfig config = featureConfigRepository
+                .findByFeatureIdAndEnvironmentAndClientId(featureId, request.environment(), request.clientId())
+                .orElseGet(() -> {
+                    FeatureConfig newConfig = new FeatureConfig();
+                    newConfig.setFeature(feature);
+                    newConfig.setClientId(request.clientId());
+                    newConfig.setEnvironment(request.environment());
+                    return newConfig;
+                });
+
+        config.setEnabled(false);
+
+        FeatureConfig saved = featureConfigRepository.save(config);
+        return FeatureConfigResponse.fromEntity(saved);
+    }
+}


### PR DESCRIPTION
Contexto:
Se implementa la Historia 6, que corresponde a la posibilidad de habilitar o deshabilitar features por "clientId" y/o "environment".

Cambios realizados:
- Creación de FeatureToggleRequest para manejar los datos de entrada.
- Implementación de FeatureConfigService con métodos enableFeature y disableFeature.
- Actualización de FeatureController para exponer los endpoints:
  - "POST /api/features/{id}/enable"
  - "POST /api/features/{id}/disable"
- Ajustes en la colección de Postman para pruebas.

Cómo probar:
1. Crear una feature usando "POST /api/features".
2. Ejecutar "POST /api/features/{id}/enable" con un body tipo json (para habilitarlo), por ejemplo:
   { "environment": "STAGING", "clientId": "acme123" }
   
3. Ejecutar "POST /api/features/{id}/disable" con un body tipo json (para deshabilitarlo), por ejemplo:
   { "environment": "STAGING", "clientId": "acme123" }